### PR TITLE
[Feat] 프로필 수정 및 토큰 재발급 기능 구현

### DIFF
--- a/bookflex/src/App.js
+++ b/bookflex/src/App.js
@@ -19,6 +19,7 @@ import LoginPage from './pages/common/LoginPage';
 import SignUpPage from './pages/common/SignUpPage'; // 수정된 이름
 import UserLayout from './pages/user/UserLayout'; // UserLayout 컴포넌트 임포트
 import ProfilePage from './pages/user/ProfilePage';
+import ProfileModifyPage from "./pages/user/ProfileModifyPage";
 import UserQnAPage from './pages/user/UserQnAPage'; // 유저 Q&A 페이지 임포트
 import AdminQnAPage from './pages/admin/AdminQnAPage'
 import BookDetailPage from './pages/user/BookDetailPage';
@@ -72,6 +73,7 @@ function App() {
                         <Route path="profile" element={<ProfilePage/>}/>
                         <Route path="qna" element={<UserQnAPage/>}/>
                         {/* 추가적인 유저 하위 라우트 설정 */}
+                        <Route path="profile-modify" element={<ProfileModifyPage/>}/>
                     </Route>
                     <Route path="/admin" element={<AdminDashboard/>}>
                         <Route path="orders" element={<OrderManagement/>}/>

--- a/bookflex/src/App.js
+++ b/bookflex/src/App.js
@@ -69,7 +69,7 @@ function App() {
                         <Route path="payment-history" element={<PaymentHistoryPage/>}/>
                         <Route path="category/:categoryName" element={<CategoryPage/>}/>
                         <Route path="wishlist" element={<WishlistPage/>}/>
-                        <Route path="profile/:userId" element={<ProfilePage/>}/>
+                        <Route path="profile" element={<ProfilePage/>}/>
                         <Route path="qna" element={<UserQnAPage/>}/>
                         {/* 추가적인 유저 하위 라우트 설정 */}
                     </Route>

--- a/bookflex/src/api/axiosInstance.jsx
+++ b/bookflex/src/api/axiosInstance.jsx
@@ -7,11 +7,64 @@ const axiosInstance = axios.create({
     },
 });
 
-const accessToken = localStorage.getItem('accessToken');
-if (accessToken) {
-    axiosInstance.defaults.headers.common['Authorization'] = accessToken;
-}
+const refreshToken = async () => {
+    try {
+        const response = await axiosInstance.post('/auth/refresh', {});
+        const accessToken = response.data.accessToken;
+        localStorage.setItem('Authorization', accessToken);
+        console.log("재발급성공");
+        return accessToken;
+    } catch (error) {
+        console.error('재발급 에러:', error.response?.data || error.message);
+        throw error;
+    }
+};
 
+// 요청 인터셉터
+axiosInstance.interceptors.request.use(
+    async (config) => {
+        if(config.url === 'auth/login') {
+            return config;
+        }
+        console.log("요청 가로채기");
+        const access_token = localStorage.getItem('Authorization');
+        const refresh_token = localStorage.getItem('refreshToken');
 
+        if (config.url === '/auth/refresh') {
+            console.log("요청세팅이 되는건가요");
+            console.log(refresh_token);
+            config.headers.setAuthorization(refresh_token);
+        } else {
+            console.log("액세스 토큰 자동보내주기");
+            config.headers.setAuthorization(access_token);
+        }
+        return config;
+    }
+);
+
+axiosInstance.interceptors.response.use(
+    (response) => {
+        return response;
+    },
+
+    async (error) => {
+        const {config, response} = error;
+        console.log(config.sent);
+        if (
+            config.url === '/auth/refresh' ||
+            response?.status !== 402 ||
+            config.sent) {
+            return Promise.reject(error);
+        }
+
+        config.sent = true;
+        const access_token = await refreshToken();
+        if(access_token) {
+            config.headers.Authorization = access_token;
+        }
+
+        return axiosInstance(config);
+    }
+)
 
 export default axiosInstance;

--- a/bookflex/src/pages/common/LoginPage.jsx
+++ b/bookflex/src/pages/common/LoginPage.jsx
@@ -17,13 +17,14 @@ const LoginPage = () => {
 
         axiosInstance.post('auth/login', data)
             .then(response => {
-                const { accessToken, auth } = response.data;
+                const { accessToken, refreshToken, auth } = response.data;
 
                 // 로그인 성공 후, 모든 axios 요청에 accessToken을 자동으로 포함시키기 위해 설정
-                axiosInstance.defaults.headers.common['Authorization'] = accessToken;
+                //axiosInstance.defaults.headers.common['Authorization'] = accessToken;
                 console.log('Login successful!', accessToken);
                 // 토큰을 localStorage에 저장 (선택 사항)
                 localStorage.setItem('Authorization', accessToken);
+                localStorage.setItem('refreshToken', refreshToken);
 
                 console.log('Authorization header after login:', axiosInstance.defaults.headers.common['Authorization']);
 

--- a/bookflex/src/pages/user/ProfilePage.jsx
+++ b/bookflex/src/pages/user/ProfilePage.jsx
@@ -1,7 +1,7 @@
-import React, {useState, useEffect } from 'react';
+import React, {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import styles from './ProfilePage.module.css'; // CSS 모듈 임포트
-import axiosInstance from "../../api/axiosInstance"; // 수정된 Axios 인스턴스 임포트
+import axiosInstance from "../../api/axiosInstance";
 
 const ProfilePage = () => {
 
@@ -20,11 +20,7 @@ const ProfilePage = () => {
     useEffect(() => {
         const getProfileResDto = async () => {
             try {
-                const response = await axiosInstance.get(`/users`, {
-                    // headers: {
-                    //     Authorization: `${token}`
-                    // },
-                });
+                const response = await axiosInstance.get(`/users`, {});
                 setUsername(response.data.username);
                 setEmail(response.data.email);
                 setAddress(response.data.address);
@@ -41,6 +37,10 @@ const ProfilePage = () => {
 
         getProfileResDto();
     }, [navigate]);
+
+    const modifyBtnClick = (e) => {
+        navigate('/main/profile-modify');
+    }
 
     return (
         <div className={styles.container}>
@@ -80,6 +80,7 @@ const ProfilePage = () => {
                     <span className={styles.value}>{createdAt}</span>
                 </div>
             </div>
+            <button className="modify-button" onClick={modifyBtnClick}>Profile Modify</button>
         </div>
     );
 };

--- a/bookflex/src/pages/user/ProfilePage.jsx
+++ b/bookflex/src/pages/user/ProfilePage.jsx
@@ -1,12 +1,12 @@
 import React, {useState, useEffect } from 'react';
-import {useNavigate, useParams} from 'react-router-dom';
+import {useNavigate} from 'react-router-dom';
 import styles from './ProfilePage.module.css'; // CSS 모듈 임포트
 import axiosInstance from "../../api/axiosInstance"; // 수정된 Axios 인스턴스 임포트
 
 const ProfilePage = () => {
-    const { userId } = useParams();
-    const token = localStorage.getItem("Authorization");
-    console.log(token);
+
+    // const token = localStorage.getItem("Authorization");
+    // console.log(token);
     const [username, setUsername] = useState('');
     const [email, setEmail] = useState('');
     const [address, setAddress] = useState('');
@@ -20,10 +20,10 @@ const ProfilePage = () => {
     useEffect(() => {
         const getProfileResDto = async () => {
             try {
-                const response = await axiosInstance.get(`/users/${userId}`, {
-                    headers: {
-                        Authorization: `${token}`
-                    },
+                const response = await axiosInstance.get(`/users`, {
+                    // headers: {
+                    //     Authorization: `${token}`
+                    // },
                 });
                 setUsername(response.data.username);
                 setEmail(response.data.email);
@@ -40,7 +40,7 @@ const ProfilePage = () => {
         };
 
         getProfileResDto();
-    }, [userId, token, navigate]);
+    }, [navigate]);
 
     return (
         <div className={styles.container}>

--- a/bookflex/src/pages/user/ProfilePage.jsx
+++ b/bookflex/src/pages/user/ProfilePage.jsx
@@ -1,12 +1,9 @@
-import React, {useEffect, useState} from 'react';
-import {useNavigate} from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styles from './ProfilePage.module.css'; // CSS 모듈 임포트
 import axiosInstance from "../../api/axiosInstance";
 
 const ProfilePage = () => {
-
-    // const token = localStorage.getItem("Authorization");
-    // console.log(token);
     const [username, setUsername] = useState('');
     const [email, setEmail] = useState('');
     const [address, setAddress] = useState('');
@@ -32,6 +29,9 @@ const ProfilePage = () => {
             } catch (error) {
                 console.error("Profile Check error", error.response ? error.response.data : error.message);
                 alert('프로필 조회에 실패하였습니다. 다시 시도해 주세요.');
+                if (error.response?.status === 401) {
+                    navigate('/login'); // 토큰이 만료되어 재발급에도 실패한 경우 로그인 페이지로 리디렉션
+                }
             }
         };
 

--- a/src/main/java/com/sparta/bookflex/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/bookflex/common/exception/ErrorCode.java
@@ -55,7 +55,7 @@ public enum ErrorCode {
     NOT_LEAF_CATEGORY(HttpStatus.BAD_REQUEST, "하위 카테고리를 선택해주세요."),
 
     // 토큰
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "이미 만료된 토큰입니다"),
+    EXPIRED_TOKEN(HttpStatus.PAYMENT_REQUIRED, "이미 만료된 토큰입니다"),
 
     // 고객문의
     QNA_CREATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "문의를 남길 수 없습니다."),

--- a/src/main/java/com/sparta/bookflex/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sparta/bookflex/common/security/JwtAuthenticationFilter.java
@@ -32,7 +32,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
 
         String token = jwtProvider.getJwtFromHeader(req, JwtConfig.AUTHORIZATION_HEADER);
-
+        String url = req.getRequestURI();
+        if(url.equals("/auth/login")) {
+            token = "";
+        }
         if (!StringUtils.hasText(token)) {
             log.info("토큰 아예 없는 경우");
             filterChain.doFilter(req, res);

--- a/src/main/java/com/sparta/bookflex/domain/systemlog/entity/SystemLog.java
+++ b/src/main/java/com/sparta/bookflex/domain/systemlog/entity/SystemLog.java
@@ -32,13 +32,12 @@ public class SystemLog {
     @CreatedDate
     private LocalDateTime createdAt;
 
-    @ManyToOne
-    @JoinColumn(name="user_id")
-    private User user;
+    @Column
+    String username;
 
     public SystemLog(ActionType action, String description, User user) {
         this.action = action;
         this.description = description;
-        this.user = user;
+        username = user.getUsername();
     }
 }

--- a/src/main/java/com/sparta/bookflex/domain/systemlog/entity/TraceOfUserLog.java
+++ b/src/main/java/com/sparta/bookflex/domain/systemlog/entity/TraceOfUserLog.java
@@ -34,17 +34,16 @@ public class TraceOfUserLog {
     private LocalDateTime createdAt;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
-
-    @ManyToOne
     @JoinColumn(name = "book_id")
     private Book book;
+
+    @Column
+    String username;
 
     public TraceOfUserLog(ActionType action, String description, User user, Book book) {
         this.activityType = action;
         this.description = description;
-        this.user = user;
         this.book = book;
+        username = user.getUsername();
     }
 }

--- a/src/main/java/com/sparta/bookflex/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.sparta.bookflex.common.config.JwtConfig;
 import com.sparta.bookflex.common.security.UserDetailsImpl;
 import com.sparta.bookflex.domain.user.dto.LoginReqDto;
 import com.sparta.bookflex.domain.user.dto.LoginResDto;
+import com.sparta.bookflex.domain.user.dto.RefreshResDto;
 import com.sparta.bookflex.domain.user.dto.SignUpReqDto;
 import com.sparta.bookflex.domain.user.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -73,12 +74,13 @@ public class AuthController {
 
     @Envelop("토큰을 재발급 하였습니다.")
     @PostMapping("/refresh")
-    public ResponseEntity<Void> refreshToken(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response, HttpServletRequest request)
+    public ResponseEntity<RefreshResDto> refreshToken(@AuthenticationPrincipal UserDetailsImpl userDetails, HttpServletResponse response, HttpServletRequest request)
     {
         String accessToken = authService.refreshToken(userDetails.getUser(), request.getHeader(JwtConfig.AUTHORIZATION_HEADER));
+        RefreshResDto resDto = new RefreshResDto(accessToken);
         response.setHeader(JwtConfig.ACCESS_TOKEN_HEADER, accessToken);
 
-        return ResponseEntity.ok().body(null);
+        return ResponseEntity.ok().body(resDto);
     }
 
 //    @GetMapping("kakao/callback")

--- a/src/main/java/com/sparta/bookflex/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/controller/UserController.java
@@ -23,19 +23,19 @@ public class UserController {
     private final UserService userService;
 
 
-    @GetMapping("/{userId}")
-    public ResponseEntity<ProfileResDto> getProfile(@PathVariable long userId, @AuthenticationPrincipal UserDetailsImpl userDetails){
+    @GetMapping()
+    public ResponseEntity<ProfileResDto> getProfile(@AuthenticationPrincipal UserDetailsImpl userDetails){
 
-        ProfileResDto resDto = userService.getProfile(userId, userDetails.getUser());
+        ProfileResDto resDto = userService.getProfile(userDetails.getUser());
         return ResponseEntity.ok().body(resDto);
     }
 
     @Envelop("프로필 수정에 성공하였습니다.")
-    @PutMapping("/{userId}")
-    public ResponseEntity<ProfileResDto> updateProfile(@PathVariable long userId, @AuthenticationPrincipal UserDetailsImpl userDetails
+    @PutMapping()
+    public ResponseEntity<ProfileResDto> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails
     ,@Valid @RequestBody ProfileReqDto reqDto) {
 
-        ProfileResDto resDto = userService.updateProfile(userId, userDetails.getUser(),
+        ProfileResDto resDto = userService.updateProfile(userDetails.getUser(),
             reqDto);
 
         return ResponseEntity.ok().body(resDto);

--- a/src/main/java/com/sparta/bookflex/domain/user/dto/RefreshResDto.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/dto/RefreshResDto.java
@@ -1,0 +1,12 @@
+package com.sparta.bookflex.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshResDto {
+    private String accessToken;
+
+    public RefreshResDto(String token) {
+        this.accessToken = token;
+    }
+}

--- a/src/main/java/com/sparta/bookflex/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/entity/User.java
@@ -93,9 +93,6 @@ public class User extends Timestamped {
     private List<Review> reviewList;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<TraceOfUserLog> copyOfSystemLogList;
-
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Shipment> shipmentList;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/sparta/bookflex/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.sparta.bookflex.domain.user.dto.StateReqDto;
 import com.sparta.bookflex.domain.user.entity.User;
 import com.sparta.bookflex.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public ProfileResDto getProfile(User user) {
 
@@ -29,8 +31,8 @@ public class UserService {
     public ProfileResDto updateProfile(User user, ProfileReqDto reqDto) {
 
         User currentUser = getUser(user);
-
-        currentUser.updateProfile(reqDto.getPassword(), reqDto.getNickname(), reqDto.getPhoneNumber(), reqDto.getAddress());
+        String password = passwordEncoder.encode(reqDto.getPassword());
+        currentUser.updateProfile(password, reqDto.getNickname(), reqDto.getPhoneNumber(), reqDto.getAddress());
 
         return User.of(currentUser);
     }

--- a/src/main/java/com/sparta/bookflex/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/bookflex/domain/user/service/UserService.java
@@ -18,45 +18,47 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public ProfileResDto getProfile(long userId, User user) {
+    public ProfileResDto getProfile(User user) {
 
-        User inputUser = getUser(userId, user);
+        User currentUser = getUser(user);
 
-        return User.of(inputUser);
+        return User.of(currentUser);
     }
 
     @Transactional
-    public ProfileResDto updateProfile(long userId, User user, ProfileReqDto reqDto) {
+    public ProfileResDto updateProfile(User user, ProfileReqDto reqDto) {
 
-        User inputUser = getUser(userId, user);
+        User currentUser = getUser(user);
 
-        inputUser.updateProfile(reqDto.getPassword(), reqDto.getNickname(), reqDto.getPhoneNumber(), reqDto.getAddress());
+        currentUser.updateProfile(reqDto.getPassword(), reqDto.getNickname(), reqDto.getPhoneNumber(), reqDto.getAddress());
 
-        return User.of(inputUser);
+        return User.of(currentUser);
     }
 
     @Transactional
     public void updateGrade(long userId, User user, GradeReqDto reqDto) {
-        User inputUser = getUser(userId, user);
+        User inputUser = getUser(userId);
 
         inputUser.updateGrade(reqDto.getUserGrade());
     }
 
     @Transactional
     public void updateState(long userId, User user, StateReqDto reqDto) {
-
-        User inputUser = userRepository.findById(userId).orElseThrow(() ->
-            new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User inputUser = getUser(userId);
 
         inputUser.updateState(reqDto.getState());
     }
 
-    private User getUser(long userId, User user) {
-        User inputUser = userRepository.findById(userId).orElseThrow(() ->
+    private User getUser(User user) {
+        User curUser = userRepository.findById(user.getId()).orElseThrow(() ->
             new BusinessException(ErrorCode.USER_NOT_FOUND));
-        if (!inputUser.getUsername().equals(user.getUsername())) {
-            throw new BusinessException(ErrorCode.USER_NOT_AUTHENTICATED);
-        }
-        return inputUser;
+
+        return curUser;
+    }
+
+    private User getUser(long userId) {
+        User curUser = userRepository.findById(userId).orElseThrow(() ->
+            new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return curUser;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,7 +15,7 @@ spring.jpa.open-in-view=false
 
 # jwt
 jwt.secret-key=7JWI64WV7ZWY7IS47JqU6rmA6r6466+47J6F64uI64uk7K2I6r647K2I6r647K2I6r647K2I6r64
-jwt.access-time=1209600000
+jwt.access-time=1800000
 jwt.refresh-time=1209600000
 # access time ??? : 1800000
 


### PR DESCRIPTION
- 프로필 수정기능 구현
- 유저 entity와 시스템 로그 entity 간 연관관계 삭제
- >> 유저가 삭제되었을때 해당 유저가 행동한 로그가 같이 다 삭제되는건 맞지않는것 같아 연관관계 삭제했습니다

- 토큰 재발급 구현하면서 프론트단에 최적화하기 위해 AuthContorller 가 약간 바뀌었습니다 (재발급시 dto로)
- 토큰 재발급 기능을 프론트에 구현하면서 axiosInstance.jsx 를 수정했습니다 (pull 후 오류있는지 확인 부탁드립니다)
- 로그인 페이지 토큰포함 부분 주석처리 했습니다
// 로그인 성공 후, 모든 axios 요청에 accessToken을 자동으로 포함시키기 위해 설정
//axiosInstance.defaults.headers.common['Authorization'] = accessToken;