### PR TITLE
쿠폰 기능 수정 (DTO에 필드 추가 등)

### DIFF
--- a/src/main/java/com/sparta/bookflex/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/controller/CouponController.java
@@ -1,6 +1,5 @@
 package com.sparta.bookflex.domain.coupon.controller;
 
-import com.sparta.bookflex.common.aop.Envelop;
 import com.sparta.bookflex.common.exception.BusinessException;
 import com.sparta.bookflex.common.security.UserDetailsImpl;
 import com.sparta.bookflex.domain.coupon.dto.CouponRequestDto;
@@ -10,7 +9,6 @@ import com.sparta.bookflex.domain.coupon.dto.UserCouponResponseDto;
 import com.sparta.bookflex.domain.coupon.enums.CouponType;
 import com.sparta.bookflex.domain.coupon.enums.DiscountType;
 import com.sparta.bookflex.domain.coupon.service.CouponService;
-import com.sparta.bookflex.domain.qna.enums.QnaTypeCode;
 import com.sparta.bookflex.domain.user.entity.User;
 import com.sparta.bookflex.domain.user.enums.RoleType;
 import com.sparta.bookflex.domain.user.enums.UserGrade;
@@ -162,8 +160,8 @@ public class CouponController {
     @GetMapping("/availables")
 //    @Envelop("발급 가능한 모든 쿠폰을 조회했습니다.")
     public ResponseEntity<List<CouponResponseDto>> getAvailableCoupons(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                    @RequestParam(value = "page", defaultValue = "1") int page,
-                                                                    @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy) {
+                                                                       @RequestParam(value = "page", defaultValue = "1") int page,
+                                                                       @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy) {
         User user = authService.findByUserName(userDetails.getUser().getUsername());
         if (user.getAuth() != RoleType.USER) {
             throw new BusinessException(COUPON_VIEW_NOT_ALLOWED);

--- a/src/main/java/com/sparta/bookflex/domain/coupon/dto/UserCouponResponseDto.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/dto/UserCouponResponseDto.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor
 public class UserCouponResponseDto {
+    private Long userCouponId;
     private String couponCode;
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
@@ -26,9 +27,9 @@ public class UserCouponResponseDto {
     private CouponResponseDto coupon;
 
     @Builder
-
-    public UserCouponResponseDto(String couponCode, LocalDateTime issuedAt, LocalDateTime expirationDate, Boolean isUsed,
-                                 LocalDateTime usedAt, CouponResponseDto coupon) {
+    public UserCouponResponseDto(Long userCouponId, String couponCode, LocalDateTime issuedAt, LocalDateTime expirationDate,
+                                 Boolean isUsed, LocalDateTime usedAt, CouponResponseDto coupon) {
+        this.userCouponId = userCouponId;
         this.couponCode = couponCode;
         this.issuedAt = issuedAt;
         this.expirationDate = expirationDate;

--- a/src/main/java/com/sparta/bookflex/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/entity/UserCoupon.java
@@ -62,6 +62,7 @@ public class UserCoupon extends Timestamped {
 
     public static UserCouponResponseDto toUserCouponResponseDto(UserCoupon userCoupon, CouponResponseDto responseDto) {
         return UserCouponResponseDto.builder()
+                .userCouponId(userCoupon.getId())
                 .couponCode(userCoupon.getCouponCode())
                 .issuedAt(userCoupon.getIssuedAt())
                 .expirationDate(userCoupon.getExpirationDate())

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepository.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepository.java
@@ -1,15 +1,19 @@
 package com.sparta.bookflex.domain.coupon.repository;
 
 import com.sparta.bookflex.domain.coupon.entity.Coupon;
-import com.sparta.bookflex.domain.user.enums.UserGrade;
+import com.sparta.bookflex.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CouponQRepository {
-    Page<Coupon> findAvailableByUserGrade(UserGrade grade, Pageable pageable);
+    Page<Coupon> findAvailableByUserGrade(User user, Pageable pageable);
 
     void deleteExpiredCoupon();
 
     void updateIssuedCoupon();
+
+    void updateGradeCoupon();
+
+    void updateBirthdayCoupon();
 
 }

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepositoryImpl.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepositoryImpl.java
@@ -2,8 +2,8 @@ package com.sparta.bookflex.domain.coupon.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.bookflex.domain.coupon.entity.Coupon;
-import com.sparta.bookflex.domain.coupon.entity.UserCoupon;
 import com.sparta.bookflex.domain.coupon.enums.CouponStatus;
+import com.sparta.bookflex.domain.coupon.enums.CouponType;
 import com.sparta.bookflex.domain.user.enums.UserGrade;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,7 +16,6 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static com.sparta.bookflex.domain.coupon.entity.QCoupon.coupon;
-import static com.sparta.bookflex.domain.coupon.entity.QUserCoupon.userCoupon;
 
 @RequiredArgsConstructor
 public class CouponQRepositoryImpl implements CouponQRepository {
@@ -29,6 +28,7 @@ public class CouponQRepositoryImpl implements CouponQRepository {
                 .where(coupon.eligibleGrade.eq(grade)
                         .and(coupon.couponStatus.eq(CouponStatus.Available))
                         .and(coupon.totalCount.gt(0))
+                        .and(coupon.couponType.ne(CouponType.BIRTHDAY))
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -39,6 +39,7 @@ public class CouponQRepositoryImpl implements CouponQRepository {
                 .where(coupon.eligibleGrade.eq(grade)
                         .and(coupon.couponStatus.eq(CouponStatus.Available))
                         .and(coupon.totalCount.gt(0))
+                        .and(coupon.couponType.ne(CouponType.BIRTHDAY))
                 )
                 .fetch();
 

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepositoryImpl.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/CouponQRepositoryImpl.java
@@ -1,18 +1,18 @@
 package com.sparta.bookflex.domain.coupon.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.bookflex.domain.coupon.entity.Coupon;
 import com.sparta.bookflex.domain.coupon.enums.CouponStatus;
 import com.sparta.bookflex.domain.coupon.enums.CouponType;
-import com.sparta.bookflex.domain.user.enums.UserGrade;
+import com.sparta.bookflex.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.*;
 import java.util.List;
 
 import static com.sparta.bookflex.domain.coupon.entity.QCoupon.coupon;
@@ -22,25 +22,48 @@ public class CouponQRepositoryImpl implements CouponQRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Coupon> findAvailableByUserGrade(UserGrade grade, Pageable pageable) {
+    public Page<Coupon> findAvailableByUserGrade(User user, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(coupon.eligibleGrade.eq(user.getGrade()));
+        builder.and(coupon.couponStatus.eq(CouponStatus.Available));
+        builder.and(coupon.totalCount.gt(0));
+
+        List<Coupon> births = queryFactory.select(coupon)
+                .from(coupon)
+                .where(coupon.couponType.eq(CouponType.BIRTHDAY))
+                .fetch();
+
+        if (user.getBirthDay() == null) {
+            builder.and(coupon.couponType.ne(CouponType.BIRTHDAY));
+        } else {
+            for (Coupon birth : births) {
+                if (user.getBirthDay().getMonthValue() != birth.getStartDate().getMonthValue()) {
+                    builder.and(coupon.id.ne(birth.getId()));
+                }
+            }
+        }
+
+        List<Coupon> grades = queryFactory.select(coupon)
+                .from(coupon)
+                .where(coupon.couponType.eq(CouponType.GRADE))
+                .fetch();
+
+        for (Coupon grade : grades) {
+            if (grade.getStartDate().isAfter(LocalDateTime.now())) {
+                builder.and(coupon.id.ne(grade.getId()));
+            }
+        }
+
         List<Coupon> result = queryFactory.select(coupon)
                 .from(coupon)
-                .where(coupon.eligibleGrade.eq(grade)
-                        .and(coupon.couponStatus.eq(CouponStatus.Available))
-                        .and(coupon.totalCount.gt(0))
-                        .and(coupon.couponType.ne(CouponType.BIRTHDAY))
-                )
+                .where(builder)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         List<Coupon> count = queryFactory.select(coupon)
                 .from(coupon)
-                .where(coupon.eligibleGrade.eq(grade)
-                        .and(coupon.couponStatus.eq(CouponStatus.Available))
-                        .and(coupon.totalCount.gt(0))
-                        .and(coupon.couponType.ne(CouponType.BIRTHDAY))
-                )
+                .where(builder)
                 .fetch();
 
         return new PageImpl<>(result, pageable, count.size());
@@ -51,7 +74,8 @@ public class CouponQRepositoryImpl implements CouponQRepository {
     public void deleteExpiredCoupon() {
         LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
         queryFactory.delete(coupon)
-                .where(coupon.expirationDate.before(now))
+                .where(coupon.expirationDate.before(now)
+                        .and(coupon.couponType.notIn(CouponType.BIRTHDAY, CouponType.GRADE)))
                 .execute();
     }
 
@@ -62,6 +86,34 @@ public class CouponQRepositoryImpl implements CouponQRepository {
         queryFactory.update(coupon)
                 .set(coupon.couponStatus, CouponStatus.Available)
                 .where(coupon.startDate.before(now))
+                .execute();
+    }
+
+    @Override
+    @Transactional
+    public void updateGradeCoupon() {
+        LocalDate start = YearMonth.now().atDay(1);
+        LocalDate end = YearMonth.now().atEndOfMonth();
+
+        queryFactory.update(coupon)
+                .set(coupon.totalCount, Integer.MAX_VALUE)
+                .set(coupon.startDate, start.atStartOfDay())
+                .set(coupon.expirationDate, end.atTime(LocalTime.MAX))
+                .where(coupon.couponType.eq(CouponType.GRADE))
+                .execute();
+    }
+
+    @Override
+    @Transactional
+    public void updateBirthdayCoupon() {
+        LocalDate start = YearMonth.now().atDay(1);
+        LocalDate end = YearMonth.now().atEndOfMonth();
+
+        queryFactory.update(coupon)
+                .set(coupon.totalCount, Integer.MAX_VALUE)
+                .set(coupon.startDate, start.atStartOfDay())
+                .set(coupon.expirationDate, end.atTime(LocalTime.MAX))
+                .where(coupon.couponType.eq(CouponType.BIRTHDAY))
                 .execute();
     }
 

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepository.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.domain.Pageable;
 public interface UserCouponQRepository {
     Page<UserCoupon> findAllByUserId(long userId, Pageable pageable);
 
-    void updateGradeCoupon();
+    void deleteUserCoupon();
 
-    void updateBirthdayCoupon();
 }
 

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepositoryImpl.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepositoryImpl.java
@@ -45,8 +45,6 @@ public class UserCouponQRepositoryImpl implements UserCouponQRepository {
     @Override
     @Transactional
     public void updateGradeCoupon() {
-        List<User> count = queryFactory.select(user).from(user).fetch();
-
         LocalDate start = YearMonth.now().atDay(1);
         LocalDate end = YearMonth.now().atEndOfMonth();
 
@@ -61,8 +59,6 @@ public class UserCouponQRepositoryImpl implements UserCouponQRepository {
     @Override
     @Transactional
     public void updateBirthdayCoupon() {
-        List<User> count = queryFactory.select(user).from(user).where(user.birthDay.isNotNull()).fetch();
-
         LocalDate start = YearMonth.now().atDay(1);
         LocalDate end = YearMonth.now().atEndOfMonth();
 

--- a/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepositoryImpl.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/repository/UserCouponQRepositoryImpl.java
@@ -2,22 +2,18 @@ package com.sparta.bookflex.domain.coupon.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.bookflex.domain.coupon.entity.UserCoupon;
-import com.sparta.bookflex.domain.coupon.enums.CouponType;
-import com.sparta.bookflex.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.YearMonth;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.sparta.bookflex.domain.coupon.entity.QCoupon.coupon;
 import static com.sparta.bookflex.domain.coupon.entity.QUserCoupon.userCoupon;
-import static com.sparta.bookflex.domain.user.entity.QUser.user;
 
 @RequiredArgsConstructor
 public class UserCouponQRepositoryImpl implements UserCouponQRepository {
@@ -44,29 +40,11 @@ public class UserCouponQRepositoryImpl implements UserCouponQRepository {
 
     @Override
     @Transactional
-    public void updateGradeCoupon() {
-        LocalDate start = YearMonth.now().atDay(1);
-        LocalDate end = YearMonth.now().atEndOfMonth();
-
-        queryFactory.update(coupon)
-                .set(coupon.totalCount, Integer.MAX_VALUE)
-                .set(coupon.startDate, start.atStartOfDay())
-                .set(coupon.expirationDate, end.atTime(LocalTime.MAX))
-                .where(coupon.couponType.eq(CouponType.GRADE))
+    public void deleteUserCoupon() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        queryFactory.delete(userCoupon)
+                .where(userCoupon.expirationDate.before(now))
                 .execute();
     }
 
-    @Override
-    @Transactional
-    public void updateBirthdayCoupon() {
-        LocalDate start = YearMonth.now().atDay(1);
-        LocalDate end = YearMonth.now().atEndOfMonth();
-
-        queryFactory.update(coupon)
-                .set(coupon.totalCount, Integer.MAX_VALUE)
-                .set(coupon.startDate, start.atStartOfDay())
-                .set(coupon.expirationDate, end.atTime(LocalTime.MAX))
-                .where(coupon.couponType.eq(CouponType.BIRTHDAY))
-                .execute();
-    }
 }

--- a/src/main/java/com/sparta/bookflex/domain/coupon/scheduler/CouponScheduler.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/scheduler/CouponScheduler.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 public class CouponScheduler {
     private final CouponScheduleService couponScheduleService;
 
-    @Scheduled(cron = "0 0 0/1 * * *") // 1시간마다
+    @Scheduled(cron = "0 0 0 * * *") //  매일 오전 12시
     public void deleteExpiredCoupon() throws InterruptedException {
         log.info("만료된 쿠폰 삭제");
         couponScheduleService.deleteExpiredCoupon();
@@ -24,15 +24,15 @@ public class CouponScheduler {
         couponScheduleService.updateIssuedCoupon();
     }
 
-    @Scheduled(cron = "0 0 0 * * *") // 매달 오전 12시
+    @Scheduled(cron = "0 0 0 * * *") // 매일 오전 12시
     public void updateGradeCoupon() throws InterruptedException {
-        log.info("등급 쿠폰 수량, 발급시작일, 발급만료일 변경");
+        log.info("발급된 등급 쿠폰들 삭제. 등급 쿠폰 수량, 발급시작일, 발급만료일 변경 후 재발급");
         couponScheduleService.updateGradeCoupon();
     }
 
-    @Scheduled(cron = "0 0 0 * * *") // 매달 오전 12시
+    @Scheduled(cron = "0 0 0 * * *") // 매일 오전 12시
     public void updateBirthdayCoupon() throws InterruptedException {
-        log.info("생일 쿠폰 수량, 발급시작일, 발급만료일 변경");
+        log.info("발급된 생일 쿠폰들 삭제. 생일 쿠폰 수량, 발급시작일, 발급만료일 변경 후 재발급");
         couponScheduleService.updateBirthdayCoupon();
     }
 

--- a/src/main/java/com/sparta/bookflex/domain/coupon/scheduler/CouponScheduler.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/scheduler/CouponScheduler.java
@@ -24,15 +24,16 @@ public class CouponScheduler {
         couponScheduleService.updateIssuedCoupon();
     }
 
-    @Scheduled(cron = "0 0 0 1 * *") // 매달 1일 오전 12시
+    @Scheduled(cron = "0 0 0 * * *") // 매달 오전 12시
     public void updateGradeCoupon() throws InterruptedException {
         log.info("등급 쿠폰 수량, 발급시작일, 발급만료일 변경");
         couponScheduleService.updateGradeCoupon();
     }
 
-    @Scheduled(cron = "0 0 0 1 * *") // 매달 1일 오전 12시
+    @Scheduled(cron = "0 0 0 * * *") // 매달 오전 12시
     public void updateBirthdayCoupon() throws InterruptedException {
         log.info("생일 쿠폰 수량, 발급시작일, 발급만료일 변경");
         couponScheduleService.updateBirthdayCoupon();
     }
+
 }

--- a/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponScheduleService.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponScheduleService.java
@@ -1,9 +1,13 @@
 package com.sparta.bookflex.domain.coupon.service;
 
+import com.sparta.bookflex.domain.coupon.entity.Coupon;
+import com.sparta.bookflex.domain.coupon.enums.CouponType;
 import com.sparta.bookflex.domain.coupon.repository.CouponRepository;
 import com.sparta.bookflex.domain.coupon.repository.UserCouponRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -11,6 +15,7 @@ public class CouponScheduleService {
 
     private final CouponRepository couponRepository;
     private final UserCouponRepository userCouponRepository;
+    private final CouponService couponService;
 
     public void deleteExpiredCoupon() {
         couponRepository.deleteExpiredCoupon();
@@ -22,9 +27,18 @@ public class CouponScheduleService {
 
     public void updateGradeCoupon() {
         userCouponRepository.updateGradeCoupon();
+        List<Coupon> coupons = couponRepository.findByCouponType(CouponType.GRADE);
+        for(Coupon coupon : coupons){
+            couponService.issueCouponToAll(coupon.getId());
+        }
     }
 
     public void updateBirthdayCoupon() {
         userCouponRepository.updateBirthdayCoupon();
+        List<Coupon> coupons = couponRepository.findByCouponType(CouponType.BIRTHDAY);
+        for(Coupon coupon : coupons){
+            couponService.issueCouponToAll(coupon.getId());
+        }
     }
+
 }

--- a/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponScheduleService.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponScheduleService.java
@@ -26,17 +26,19 @@ public class CouponScheduleService {
     }
 
     public void updateGradeCoupon() {
-        userCouponRepository.updateGradeCoupon();
+        userCouponRepository.deleteUserCoupon();
+        couponRepository.updateGradeCoupon();
         List<Coupon> coupons = couponRepository.findByCouponType(CouponType.GRADE);
-        for(Coupon coupon : coupons){
+        for (Coupon coupon : coupons) {
             couponService.issueCouponToAll(coupon.getId());
         }
     }
 
     public void updateBirthdayCoupon() {
-        userCouponRepository.updateBirthdayCoupon();
+        userCouponRepository.deleteUserCoupon();
+        couponRepository.updateBirthdayCoupon();
         List<Coupon> coupons = couponRepository.findByCouponType(CouponType.BIRTHDAY);
-        for(Coupon coupon : coupons){
+        for (Coupon coupon : coupons) {
             couponService.issueCouponToAll(coupon.getId());
         }
     }

--- a/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/service/CouponService.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.List;
 
@@ -64,7 +63,7 @@ public class CouponService {
                 .eligibleGrade(requestDto.getEligibleGrade())
                 .couponStatus(status)
                 .startDate(requestDto.getStartDate().atStartOfDay())
-                .expirationDate(requestDto.getExpirationDate().atTime(23,59,59))
+                .expirationDate(requestDto.getExpirationDate().atTime(23, 59, 59))
                 .build();
 
         couponRepository.save(coupon);
@@ -269,7 +268,7 @@ public class CouponService {
         Sort sort = Sort.by(Sort.Direction.ASC, sortBy);
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, sort);
 
-        Page<CouponResponseDto> couponPage = couponRepository.findAvailableByUserGrade(user.getGrade(), pageable).map(Coupon::toCouponResponseDto);
+        Page<CouponResponseDto> couponPage = couponRepository.findAvailableByUserGrade(user, pageable).map(Coupon::toCouponResponseDto);
         return couponPage.getContent();
     }
 


### PR DESCRIPTION
- CouponQRepositoryImpl
1. 발급 가능한 쿠폰 찾을 때 생일 쿠폰은 제외

- UserCouponResponseDto, UserCoupon의 toDTO 메소드
1. 프론트에서 목록 조회할 때 키 값이 필요해서 userCouponId 추가

- UserCouponQRepositoryImpl
1. 안 쓰는 코드 삭제

- CouponScheduler
1. 생일쿠폰과 등급쿠폰 상태 변경 후 자동 발급
2. 매월 1일 오전 12시에서 매일 오전 12시로 실행시간 변경 (월중에 회원가입한 사람들에게도 자동으로 발급되어야 하므로.)