### PR TITLE
미사용 API 삭제

### DIFF
--- a/src/main/java/com/sparta/bookflex/domain/coupon/controller/CouponController.java
+++ b/src/main/java/com/sparta/bookflex/domain/coupon/controller/CouponController.java
@@ -106,21 +106,6 @@ public class CouponController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("/issue/{userId}/{couponId}")
-//    @Envelop("사용자에게 쿠폰이 발급되었습니다.")
-    public ResponseEntity<UserCouponResponseDto> issueCouponToUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                   @PathVariable long userId,
-                                                                   @PathVariable long couponId) {
-        User user = authService.findByUserName(userDetails.getUser().getUsername());
-        if (user.getAuth() != RoleType.ADMIN) {
-            throw new BusinessException(COUPON_ISSUE_NOT_ALLOWED);
-        }
-
-        UserCouponResponseDto responseDto = couponService.issueCouponToUser(couponId, userId);
-
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
-    }
-
     @PostMapping("/issue/{couponId}")
     public ResponseEntity<UserCouponResponseDto> issueCoupon(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                              @PathVariable long couponId) {

--- a/src/main/java/com/sparta/bookflex/domain/qna/controller/QnaController.java
+++ b/src/main/java/com/sparta/bookflex/domain/qna/controller/QnaController.java
@@ -45,17 +45,6 @@ public class QnaController {
         return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
-
-    @GetMapping("/{qnaId}")
-    public ResponseEntity<QnaResponseDto> getSingleQna(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                       @PathVariable long qnaId) {
-
-        User user = authService.findByUserName(userDetails.getUser().getUsername());
-
-        QnaResponseDto responseDto = qnaService.getSingleQna(qnaId);
-        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
-    }
-
     @GetMapping
     public ResponseEntity<Page<QnaResponseDto>> getUserQnas(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                             @RequestParam(value = "page", defaultValue = "1") int page,

--- a/src/main/java/com/sparta/bookflex/domain/qna/service/QnaService.java
+++ b/src/main/java/com/sparta/bookflex/domain/qna/service/QnaService.java
@@ -45,15 +45,6 @@ public class QnaService {
     }
 
     @Transactional(readOnly = true)
-    public QnaResponseDto getSingleQna(long qnaId) {
-        Qna qna = qnaRepository.findById(qnaId).orElseThrow(
-                () -> new BusinessException(QNA_NOT_FOUND)
-        );
-
-        return toQnaResponseDto(qna);
-    }
-
-    @Transactional(readOnly = true)
     public Page<QnaResponseDto> getUserQnas(User user, int page, String sortBy) {
         Sort sort = Sort.by(Sort.Direction.DESC, sortBy);
         Pageable pageable = PageRequest.of(page, PAGE_SIZE, sort);


### PR DESCRIPTION
특정 유저에게 쿠폰 발급, 고객문의 단건 조회 API 삭제

삭제 이유
1. 미사용
2. 다른 API로 대체 가능(쿠폰 전체 발급, 고객문의 조회)