### PR TITLE
고객문의 페이지 수정

### DIFF
--- a/bookflex/src/pages/admin/AdminQnAPage.jsx
+++ b/bookflex/src/pages/admin/AdminQnAPage.jsx
@@ -9,6 +9,7 @@ const QnaItem = ({qna, onReplyClick, onDeleteClick}) => (
     <tr>
         <td>{qna.qnaType}</td>
         <td>{qna.inquiry}</td>
+        <td>{qna.username}</td>
         <td>{qna.createdAt}</td>
         <td>{qna.reply}</td>
         <td>
@@ -159,6 +160,7 @@ const AdminQnAPage = () => {
                 <tr>
                     <th>문의 유형</th>
                     <th>문의 내용</th>
+                    <th>작성자</th>
                     <th>문의 접수일</th>
                     <th>답변</th>
                     <th>작업</th>

--- a/bookflex/src/pages/user/UserQnAPage.jsx
+++ b/bookflex/src/pages/user/UserQnAPage.jsx
@@ -3,10 +3,11 @@ import axiosInstance from "../../api/axiosInstance";
 import styles from './userqna.module.css';
 
 // QnaItem 컴포넌트 정의
-const QnaItem = ({qna, onDeleteClick}) => (
+const QnaItem = ({ qna, onDeleteClick }) => (
     <tr>
         <td>{qna.qnaType}</td>
         <td>{qna.inquiry}</td>
+        <td>{qna.username}</td> {/* Displaying the username */}
         <td>{qna.createdAt}</td>
         <td>{qna.reply}</td>
         <td>
@@ -16,6 +17,7 @@ const QnaItem = ({qna, onDeleteClick}) => (
         </td>
     </tr>
 );
+
 
 const UserQnaPage = () => {
     const [qnaList, setQnaList] = useState([]);
@@ -171,10 +173,10 @@ const UserQnaPage = () => {
                 <tr>
                     <th>문의 유형</th>
                     <th>문의 내용</th>
+                    <th>작성자</th> {/* Added header for the username */}
                     <th>문의 접수일</th>
                     <th>답변</th>
                     <th>삭제</th>
-                    {/* 삭제 열 추가 */}
                 </tr>
                 </thead>
                 <tbody>

--- a/src/main/java/com/sparta/bookflex/domain/qna/dto/QnaResponseDto.java
+++ b/src/main/java/com/sparta/bookflex/domain/qna/dto/QnaResponseDto.java
@@ -2,6 +2,7 @@ package com.sparta.bookflex.domain.qna.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sparta.bookflex.domain.qna.enums.QnaTypeCode;
+import com.sparta.bookflex.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,17 +16,21 @@ public class QnaResponseDto {
     private QnaTypeCode qnaType;
     private String inquiry;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
     private String reply;
 
+    private String username;
+
     @Builder
-    public QnaResponseDto(long qnaId, QnaTypeCode qnaType, String inquiry, LocalDateTime createdAt, String reply) {
+    public QnaResponseDto(long qnaId, QnaTypeCode qnaType, String inquiry, LocalDateTime createdAt, String reply, String username) {
         this.qnaId = qnaId;
         this.qnaType = qnaType;
         this.inquiry = inquiry;
         this.createdAt = createdAt;
         this.reply = reply;
+        this.username = username;
     }
+
 }

--- a/src/main/java/com/sparta/bookflex/domain/qna/entity/Qna.java
+++ b/src/main/java/com/sparta/bookflex/domain/qna/entity/Qna.java
@@ -52,6 +52,7 @@ public class Qna extends Timestamped {
                 .inquiry(qna.getInquiry())
                 .createdAt(qna.getCreatedAt())
                 .reply(qna.getReply())
+                .username(qna.getUser().getUsername())
                 .build();
     }
 


### PR DESCRIPTION
고객문의 페이지 유저피드백 반영

24.08.16 유저 피드백 중
"- user 계정으로 사용했는데 다른 사람이 남긴 User Q&A가 삭제가 되었습니다 ㅠ 어드민 계정이 아니라면 user 끼리 서로 Q&A를 수정또는 삭제가 가능한것 같습니다."

란 내용이 있어서 확인해보니 유저는 본인이 작성한 문의만 조회 및 삭제가 가능했습니다. 화면에서 문의 작성자가 표시되지 않아 생긴 문제 같아 조회 결과에 username 필드를 작성자로 추가했습니다.

1. 유저, 관리자 페이지에서 문의 작성자가 출력되게끔 수정
2. QnaResponseDto에 username 필드 추가